### PR TITLE
Fixed problem when get_password decorator destroys function it decorates

### DIFF
--- a/flask_httpauth.py
+++ b/flask_httpauth.py
@@ -26,6 +26,7 @@ class HTTPAuth(object):
 
     def get_password(self, f):
         self.get_password_callback = f
+        return f
 
     def error_handler(self, f):
         @wraps(f)


### PR DESCRIPTION
Code below wont work without this fix, 
because decorator returns `None`

``` python
users = {
    "admin": "admin"
}
@auth.get_password
def get_pw(username):
    if username in users:
        return users[username]
    return None

get_pw("admin")
```
