### PR TITLE
Ignore authentication headers for OPTIONS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,2 @@
+Miguel Grinberg <miguelgrinberg50@gmail.com>
+Henrique Carvalho Alves <hcarvalhoalves@gmail.com>


### PR DESCRIPTION
We need to ignore authentication headers for OPTIONS to avoid unwanted interactions with CORS.
Chrome and Firefox issue a preflight OPTIONS request to check Access-Control-\* headers, and will fail if it returns 401.

More at https://developer.mozilla.org/en-US/docs/HTTP/Access_control_CORS#Overview
