### PR TITLE
Fix #12, an attribute error on HTTPDigestAuth due to misled inheritance

### DIFF
--- a/flask_httpauth.py
+++ b/flask_httpauth.py
@@ -89,7 +89,7 @@ class HTTPBasicAuth(HTTPAuth):
                 client_password = self.hash_password_callback(auth.username, client_password)
         return client_password == stored_password
 
-class HTTPDigestAuth(HTTPAuth):
+class HTTPDigestAuth(HTTPBasicAuth):
     def __init__(self):
         super(HTTPDigestAuth, self).__init__()
         self.random = SystemRandom()


### PR DESCRIPTION
Because HTTPDigestAuth inherited from HttpAuth and not HttpBasicAuth
the use of hash_password, verify_password, etc. led to an error.
