### PR TITLE
Ha1 password option

### DIFF
--- a/flask_httpauth.py
+++ b/flask_httpauth.py
@@ -95,8 +95,9 @@ class HTTPBasicAuth(HTTPAuth):
 
 
 class HTTPDigestAuth(HTTPAuth):
-    def __init__(self):
+    def __init__(self, use_ha1_pw = False):
         super(HTTPDigestAuth, self).__init__()
+        self.use_ha1_pw = use_ha1_pw
         self.random = SystemRandom()
         try:
             self.random.random()
@@ -119,8 +120,11 @@ class HTTPDigestAuth(HTTPAuth):
         if auth.nonce != session.get("auth_nonce") or \
                 auth.opaque != session.get("auth_opaque"):
             return False
-        a1 = auth.username + ":" + auth.realm + ":" + password
-        ha1 = md5(a1.encode('utf-8')).hexdigest()
+        if self.use_ha1_pw:
+            ha1 = password
+        else:
+            a1 = auth.username + ":" + auth.realm + ":" + password
+            ha1 = md5(a1.encode('utf-8')).hexdigest()
         a2 = request.method + ":" + auth.uri
         ha2 = md5(a2.encode('utf-8')).hexdigest()
         a3 = ha1 + ":" + auth.nonce + ":" + ha2

--- a/flask_httpauth.py
+++ b/flask_httpauth.py
@@ -107,6 +107,11 @@ class HTTPDigestAuth(HTTPAuth):
     def get_nonce(self):
         return md5(str(self.random.random()).encode('utf-8')).hexdigest()
 
+    def generate_ha1(self, username, password):
+        a1 = username + ":" + self.realm + ":" + password
+        a1 = a1.encode('utf-8')
+        return md5(a1).hexdigest()
+
     def authenticate_header(self):
         session["auth_nonce"] = self.get_nonce()
         session["auth_opaque"] = self.get_nonce()

--- a/test_httpauth.py
+++ b/test_httpauth.py
@@ -33,7 +33,6 @@ class HTTPAuthTestCase(unittest.TestCase):
 
         @digest_auth_ha1_pw.get_password
         def get_digest_password(username):
-
             if username == 'susan':
                 return get_ha1(username, 'hello', digest_auth_ha1_pw.realm)
             elif username == 'john':
@@ -370,6 +369,11 @@ class HTTPAuthTestCase(unittest.TestCase):
         self.assertTrue(re.match(r'^Digest realm="Authentication Required",'
                                  r'nonce="[0-9a-f]+",opaque="[0-9a-f]+"$',
                                  response.headers['WWW-Authenticate']))
+
+    def test_digest_generate_ha1(self):
+        ha1 = self.digest_auth.generate_ha1('pawel', 'test')
+        ha1_expected = get_ha1('pawel', 'test', self.digest_auth.realm)
+        self.assertEqual(ha1, ha1_expected)
 
 
 def suite():

--- a/test_httpauth.py
+++ b/test_httpauth.py
@@ -12,6 +12,9 @@ def md5(str):
         str = str.encode('utf-8')
     return basic_md5(str)
 
+def get_ha1(user, pw, realm):
+    a1 = user + ":" + realm + ":" + pw
+    return md5(a1.encode('utf-8')).hexdigest()
 
 class HTTPAuthTestCase(unittest.TestCase):
     def setUp(self):
@@ -26,6 +29,16 @@ class HTTPAuthTestCase(unittest.TestCase):
         digest_auth = HTTPDigestAuth()
         digest_auth_my_realm = HTTPDigestAuth()
         digest_auth_my_realm.realm = 'My Realm'
+        digest_auth_ha1_pw = HTTPDigestAuth(use_ha1_pw = True)
+
+        @digest_auth_ha1_pw.get_password
+        def get_digest_password(username):
+            if username == 'susan':
+                return get_ha1(username, 'hello', digest_auth_ha1_pw.realm)
+            elif username == 'john':
+                return get_ha1(username, 'bye', digest_auth_ha1_pw.realm)
+            else:
+                return None
 
         @basic_auth.get_password
         def get_basic_password(username):
@@ -119,6 +132,11 @@ class HTTPAuthTestCase(unittest.TestCase):
         @app.route('/digest')
         @digest_auth.login_required
         def digest_auth_route():
+            return 'digest_auth:' + digest_auth.username()
+
+        @app.route('/digest_ha1_pw')
+        @digest_auth_ha1_pw.login_required
+        def digest_auth_ha1_pw_route():
             return 'digest_auth:' + digest_auth.username()
 
         @app.route('/digest-with-realm')
@@ -236,6 +254,30 @@ class HTTPAuthTestCase(unittest.TestCase):
 
     def test_digest_auth_login_valid(self):
         response = self.client.get('/digest')
+        self.assertTrue(response.status_code == 401)
+        header = response.headers.get('WWW-Authenticate')
+        auth_type, auth_info = header.split(None, 1)
+        d = parse_dict_header(auth_info)
+
+        a1 = 'john:' + d['realm'] + ':bye'
+        ha1 = md5(a1).hexdigest()
+        a2 = 'GET:/digest'
+        ha2 = md5(a2).hexdigest()
+        a3 = ha1 + ':' + d['nonce'] + ':' + ha2
+        auth_response = md5(a3).hexdigest()
+
+        response = self.client.get(
+            '/digest', headers={
+                'Authorization': 'Digest username="john",realm="{0}",'
+                                 'nonce="{1}",uri="/digest",response="{2}",'
+                                 'opaque="{3}"'.format(d['realm'],
+                                                       d['nonce'],
+                                                       auth_response,
+                                                       d['opaque'])})
+        self.assertEqual(response.data, b'digest_auth:john')
+
+    def test_digest_ha1_pw_auth_login_valid(self):
+        response = self.client.get('/digest_ha1_pw')
         self.assertTrue(response.status_code == 401)
         header = response.headers.get('WWW-Authenticate')
         auth_type, auth_info = header.split(None, 1)

--- a/test_httpauth.py
+++ b/test_httpauth.py
@@ -14,7 +14,7 @@ def md5(str):
 
 def get_ha1(user, pw, realm):
     a1 = user + ":" + realm + ":" + pw
-    return md5(a1.encode('utf-8')).hexdigest()
+    return md5(a1).hexdigest()
 
 class HTTPAuthTestCase(unittest.TestCase):
     def setUp(self):
@@ -33,6 +33,7 @@ class HTTPAuthTestCase(unittest.TestCase):
 
         @digest_auth_ha1_pw.get_password
         def get_digest_password(username):
+
             if username == 'susan':
                 return get_ha1(username, 'hello', digest_auth_ha1_pw.realm)
             elif username == 'john':
@@ -285,7 +286,7 @@ class HTTPAuthTestCase(unittest.TestCase):
 
         a1 = 'john:' + d['realm'] + ':bye'
         ha1 = md5(a1).hexdigest()
-        a2 = 'GET:/digest'
+        a2 = 'GET:/digest_ha1_pw'
         ha2 = md5(a2).hexdigest()
         a3 = ha1 + ':' + d['nonce'] + ':' + ha2
         auth_response = md5(a3).hexdigest()
@@ -293,7 +294,7 @@ class HTTPAuthTestCase(unittest.TestCase):
         response = self.client.get(
             '/digest', headers={
                 'Authorization': 'Digest username="john",realm="{0}",'
-                                 'nonce="{1}",uri="/digest",response="{2}",'
+                                 'nonce="{1}",uri="/digest_ha1_pw",response="{2}",'
                                  'opaque="{3}"'.format(d['realm'],
                                                        d['nonce'],
                                                        auth_response,


### PR DESCRIPTION
Added the ability to pass a flag to HttpDigestAuth in order to use 'ha1' combination of username + realm + password as the password stored for a user. I added this feature so that when storing users in the database, the application does not have to store the actual plain text password.
