### PR TITLE
Remove session dependency in authenticate_header

### DIFF
--- a/flask_httpauth.py
+++ b/flask_httpauth.py
@@ -165,11 +165,11 @@ class HTTPDigestAuth(HTTPAuth):
         return md5(a1).hexdigest()
 
     def authenticate_header(self):
-        session["auth_nonce"] = self.get_nonce()
-        session["auth_opaque"] = self.get_opaque()
+        nonce = self.get_nonce()
+        opaque = self.get_opaque()
         return '{0} realm="{1}",nonce="{2}",opaque="{3}"'.format(
-            self.scheme or 'Digest', self.realm, session["auth_nonce"],
-            session["auth_opaque"])
+            self.scheme or 'Digest', self.realm, nonce,
+            opaque)
 
     def authenticate(self, auth, stored_password_or_ha1):
         if not auth or not auth.username or not auth.realm or not auth.uri \


### PR DESCRIPTION
Even when you provide a custom nonce/opaque storage mechanism for HTTPDigestAuth, session is still being accessed. This is unnecessary as appropriate session variables are already being set by the default mechanism and breaks apps that don't use sessions at all (i.e. don't set the SECRET_KEY).

The change proposed here seems to be enough to fix the problem.