### PR TITLE
Documentation fix, validate_token() -> verify_token()

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -139,8 +139,8 @@ The following example application uses a custom HTTP authentication scheme to pr
         "secret-token-2": "susan"
     }
 
-    @auth.validate_token
-    def validate_token(token):
+    @auth.verify_token
+    def verify_token(token):
         if token in tokens:
             g.current_user = tokens[token]
             return True


### PR DESCRIPTION
Fixed an code example in the token authentication documentation
where the example shows usage of a validate_token() method, which as
far as I can tell does not exist. I believe the the code example should
be using the verify_token() method instead.