### PR TITLE
Catching exception when Authorization header is empty

### DIFF
--- a/flask_httpauth.py
+++ b/flask_httpauth.py
@@ -60,9 +60,14 @@ class HTTPAuth(object):
                 # Flask/Werkzeug do not recognize any authentication types
                 # other than Basic or Digest, so here we parse the header by
                 # hand
-                auth_type, token = request.headers['Authorization'].split(
-                    None, 1)
-                auth = Authorization(auth_type, {'token': token})
+                try:
+                    auth_type, token = request.headers['Authorization'].split(
+                        None, 1)
+                    auth = Authorization(auth_type, {'token': token})
+                except ValueError:
+                    # The Authorization header is either empty or has no token
+                    pass
+
             if auth is not None and auth.type.lower() != self.scheme.lower():
                 return self.auth_error_callback()
             # Flask normally handles OPTIONS requests on its own, but in the


### PR DESCRIPTION
Currently, if the browser sends a:
  Authorized: Token
(where Token can be another auth token) or simply:
  Authorized: <blank>
http header, the split() method raises a ValueError resulting in a 500 error.
This errenous and basically useless header should (probably) be handled in the same manner as if there was no authorization header at all. I believe catching the exception and doing nothing achives that effect.

Thank you!