### PR TITLE
Fix TCP Connection reset by peer error

### DIFF
--- a/flask_httpauth.py
+++ b/flask_httpauth.py
@@ -84,7 +84,7 @@ class HTTPAuth(object):
                 else:
                     password = None
                 if not self.authenticate(auth, password):
-                    #Clear TCP receive buffer of any pending data
+                    # Clear TCP receive buffer of any pending data
                     request.data
                     return self.auth_error_callback()
 

--- a/flask_httpauth.py
+++ b/flask_httpauth.py
@@ -84,7 +84,10 @@ class HTTPAuth(object):
                 else:
                     password = None
                 if not self.authenticate(auth, password):
+                    #Clear TCP receive buffer of any pending data
+                    request.data
                     return self.auth_error_callback()
+
             return f(*args, **kwargs)
         return decorated
 


### PR DESCRIPTION
Purge tcp kernel buffer to fix race condition that causes 104 connection reset by peer errors.  Further described in #38 