### PR TITLE
Include docs and tests in pypi source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include README.md LICENSE
+recursive-include tests *.py
+recursive-include docs *


### PR DESCRIPTION
We are packaging Flask-HTTPAuth for Fedora, we need docs
and tests files during package build process. This patch
includes tests and docs folder in source tarball.

https://bugzilla.redhat.com/show_bug.cgi?id=1451411