### PR TITLE
Update PyPI link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,5 +79,5 @@ Resources
 ---------
 
 - [Documentation](http://flask-httpauth.readthedocs.io/en/latest/)
-- [PyPI](https://pypi.python.org/pypi/Flask-HTTPAuth)
+- [PyPI](https://pypi.org/project/Flask-HTTPAuth)
 - [Change log](https://github.com/miguelgrinberg/Flask-HTTPAuth/blob/master/CHANGELOG.md)


### PR DESCRIPTION
https://pypi.python.org is deprecated.