### PR TITLE
on bad auth don't ask browser to prompt user if this was an AJAX request

### DIFF
--- a/flask_httpauth.py
+++ b/flask_httpauth.py
@@ -46,10 +46,10 @@ class HTTPAuth(object):
                 # if user didn't set status code, use 401
                 res.status_code = 401
             # don't ask browser to prompt user if this was an AJAX request
-            if (request.headers.get('X-Requested-With', '').lower() != 
-                'xmlhttprequest') :
+            if (request.headers.get('X-Requested-With', '').lower() !=
+                    'xmlhttprequest'):
                 if 'WWW-Authenticate' not in res.headers.keys():
-                    res.headers['WWW-Authenticate'] = self.authenticate_header()
+                    res.headers['WWW-Authenticate']=self.authenticate_header()
             return res
         self.auth_error_callback = decorated
         return decorated

--- a/flask_httpauth.py
+++ b/flask_httpauth.py
@@ -48,8 +48,9 @@ class HTTPAuth(object):
             # don't ask browser to prompt user if this was an AJAX request
             if (request.headers.get('X-Requested-With', '').lower() !=
                     'xmlhttprequest'):
-                if 'WWW-Authenticate' not in res.headers.keys():
-                    res.headers['WWW-Authenticate']=self.authenticate_header()
+                hdrs = res.headers
+                if 'WWW-Authenticate' not in hdrs.keys():
+                    hdrs['WWW-Authenticate'] = self.authenticate_header()
             return res
         self.auth_error_callback = decorated
         return decorated

--- a/flask_httpauth.py
+++ b/flask_httpauth.py
@@ -45,8 +45,11 @@ class HTTPAuth(object):
             if res.status_code == 200:
                 # if user didn't set status code, use 401
                 res.status_code = 401
-            if 'WWW-Authenticate' not in res.headers.keys():
-                res.headers['WWW-Authenticate'] = self.authenticate_header()
+            # don't ask browser to prompt user if this was an AJAX request
+            if (request.headers.get('X-Requested-With', '').lower() != 
+                'xmlhttprequest') :
+                if 'WWW-Authenticate' not in res.headers.keys():
+                    res.headers['WWW-Authenticate'] = self.authenticate_header()
             return res
         self.auth_error_callback = decorated
         return decorated

--- a/tests/test_basic_verify_password.py
+++ b/tests/test_basic_verify_password.py
@@ -61,12 +61,11 @@ class HTTPAuthTestCase(unittest.TestCase):
     def test_verify_auth_login_invalid_ajax(self):
         creds = base64.b64encode(b'john:bye').decode('utf-8')
         response = self.client.get(
-            '/basic-verify', 
+            '/basic-verify',
             headers={
                 'Authorization': 'Basic ' + creds,
-                'X-Requested-With' : 'XMLHttpRequest'
+                'X-Requested-With': 'XMLHttpRequest'
             }
         )
         self.assertEqual(response.status_code, 403)
         self.assertFalse('WWW-Authenticate' in response.headers)
-

--- a/tests/test_basic_verify_password.py
+++ b/tests/test_basic_verify_password.py
@@ -57,3 +57,16 @@ class HTTPAuthTestCase(unittest.TestCase):
             '/basic-verify', headers={'Authorization': 'Basic ' + creds})
         self.assertEqual(response.status_code, 403)
         self.assertTrue('WWW-Authenticate' in response.headers)
+
+    def test_verify_auth_login_invalid_ajax(self):
+        creds = base64.b64encode(b'john:bye').decode('utf-8')
+        response = self.client.get(
+            '/basic-verify', 
+            headers={
+                'Authorization': 'Basic ' + creds,
+                'X-Requested-With' : 'XMLHttpRequest'
+            }
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertFalse('WWW-Authenticate' in response.headers)
+


### PR DESCRIPTION
The WWW-Authenticate header causes the browser to pop up an interactive dialog on 401 Unauthorized responses.  This is undesirable if the request was made via AJAX 