### PR TITLE
docs: added notes about password storing security

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ if __name__ == '__main__':
     app.run()
 ```
 
-Note: See the [documentation](http://pythonhosted.org/Flask-HTTPAuth) for more complex examples that involve password hashing and custom verification callbacks.
+Important security note: Authentication method showed in this example (using a function decorated with `@auth.get_password`) requires passwords to be stored as a clear text or passwords hashed on client side without a salt. Do not use it in production environment as it usually would be a critical security issue. See the [documentation](http://pythonhosted.org/Flask-HTTPAuth) for more complex examples that involve password hashing and custom verification callbacks.
 
 Digest authentication example
 -----------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ The following example application uses HTTP Basic authentication to protect rout
     if __name__ == '__main__':
         app.run()
         
-The ``get_password`` callback needs to return the password associated with the username given as argument. Flask-HTTPAuth will allow access only if ``get_password(username) == password``.
+The ``get_password`` callback needs to return the password associated with the username given as argument. Flask-HTTPAuth will allow access only if ``get_password(username) == password``. Note that this requires storing clear text passwords on a server, so in most cases it would be a critical security issue. For high password storing security Flask-HTTPAuth provides ``verify_password`` callback. It allows using hashing algorithms which require their own password verification functions. See the ``examples/basic_auth.py`` directory for basic implementation using ``werkzeug.security.generate_password_hash`` and it's default algorithm: ``pbkdf2:sha256``.
 
 If the passwords are stored hashed in the user database then an additional callback is needed::
 


### PR DESCRIPTION
I didn't do much, as there is already a good example in `examples` directory (about which I didn't know), so I've just added some notes in docs.
I dunno if this PR makes sense, because careful reader can already find in the documentation sentences pointing to this directory.
Closes #80 
