### PR TITLE
Add a custom authorization header option

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -197,6 +197,7 @@ API Documentation
 
     The ``realm`` argument can be used to provide an application defined realm with the ``WWW-Authenticate`` header.
 
+
   .. method:: get_password(password_callback)
 
     This callback function will be called by the framework to obtain the password for a given user. Example::
@@ -331,13 +332,15 @@ API Documentation
 
   This class handles HTTP authentication with custom schemes for Flask routes.
 
-  .. method:: __init__(scheme='Bearer', realm=None)
+  .. method:: __init__(scheme='Bearer', realm=None, header=None)
 
     Create a token authentication object.
 
     The ``scheme`` argument can be use to specify the scheme to be used in the ``WWW-Authenticate`` response.
 
     The ``realm`` argument can be used to provide an application defined realm with the ``WWW-Authenticate`` header.
+
+    The ``header`` optional argument, defaults to ``Authorization``. It can be used to define a custom token header.
 
   .. method:: verify_token(verify_token_callback)
 

--- a/flask_httpauth.py
+++ b/flask_httpauth.py
@@ -63,14 +63,13 @@ class HTTPAuth(object):
 
     def get_auth(self):
         auth = request.authorization
-        if (auth is None and "Authorization" in request.headers)\
-                or self.header in request.headers:
+        header = "Authorization" if "Authorization" in request.headers else self.header
+        if auth is None and header in request.headers:
             # Flask/Werkzeug do not recognize any authentication types
             # other than Basic or Digest, so here we parse the header by
             # hand
             try:
-                auth_type, token = request.headers[
-                    self.header or "Authorization"].split(None, 1)
+                auth_type, token = request.headers[header].split(None, 1)
                 auth = Authorization(auth_type, {'token': token})
             except (ValueError, KeyError):
                 # The Authorization header is either empty or has no token

--- a/flask_httpauth.py
+++ b/flask_httpauth.py
@@ -19,9 +19,10 @@ __version__ = '3.3.1dev'
 
 
 class HTTPAuth(object):
-    def __init__(self, scheme=None, realm=None):
+    def __init__(self, scheme=None, realm=None, header=None):
         self.scheme = scheme
         self.realm = realm or "Authentication Required"
+        self.header = header
         self.get_password_callback = None
         self.get_user_roles_callback = None
         self.auth_error_callback = None
@@ -62,15 +63,16 @@ class HTTPAuth(object):
 
     def get_auth(self):
         auth = request.authorization
-        if auth is None and 'Authorization' in request.headers:
+        if (auth is None and "Authorization" in request.headers)\
+                or self.header in request.headers:
             # Flask/Werkzeug do not recognize any authentication types
             # other than Basic or Digest, so here we parse the header by
             # hand
             try:
-                auth_type, token = request.headers['Authorization'].split(
-                    None, 1)
+                auth_type, token = request.headers[
+                    self.header or "Authorization"].split(None, 1)
                 auth = Authorization(auth_type, {'token': token})
-            except ValueError:
+            except (ValueError, KeyError):
                 # The Authorization header is either empty or has no token
                 pass
 
@@ -295,8 +297,8 @@ class HTTPDigestAuth(HTTPAuth):
 
 
 class HTTPTokenAuth(HTTPAuth):
-    def __init__(self, scheme='Bearer', realm=None):
-        super(HTTPTokenAuth, self).__init__(scheme, realm)
+    def __init__(self, scheme='Bearer', realm=None, header=None):
+        super(HTTPTokenAuth, self).__init__(scheme, realm, header)
 
         self.verify_token_callback = None
 

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -107,17 +107,15 @@ class HTTPAuthTestCase(unittest.TestCase):
     def test_token_auth_custom_header_invalid_token(self):
         self.token_auth.header = 'X-API-Key'
         response = self.client.get(
-            '/protected', headers={'X-API-Key': 'invalid-token-should-fail'})
+            '/protected', headers={'X-API-Key': 'Schema invalid-token-should-fail'})
         self.assertEqual(response.status_code, 401)
         self.assertTrue('WWW-Authenticate' in response.headers)
 
-    def test_token_auth_custom_header_over_default_token(self):
+    def test_token_auth_default_header_precedence_over_custom(self):
         self.token_auth.header = 'X-API-Key'
-        default_token_response = self.client.get(
-            '/protected', headers={'Authorization': 'MyToken this-is-the-token!'})
-        custom_token_response = self.client.get(
+        response = self.client.get(
             '/protected', headers={'Authorization': 'MyToken this-is-the-token!',
-                                   'X-API-Key': 'MyToken this-is-the-token!'})
+                                   'X-API-Key': 'MyToken invalid-token-should-fail'})
 
-        self.assertEqual(default_token_response.status_code, 401)
-        self.assertEqual(custom_token_response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data.decode('utf-8'), 'token_auth:user')


### PR DESCRIPTION
**Problem**:
- Some callback APIs don't use standard authorization headers 

**Solution**:
- Add a custom header option to `HTTPAuth` and `HTTPTokenAuth`
- Add tests and update documentation

**Related Issues**:
https://github.com/miguelgrinberg/Flask-HTTPAuth/issues/96

Thanks for the awesome extension!

