### PR TITLE
Select the closest auth according to auth type

### DIFF
--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -1,7 +1,11 @@
 import base64
+import hashlib
+import re
 import unittest
 from flask import Flask
-from flask_httpauth import HTTPBasicAuth, HTTPTokenAuth, MultiAuth
+from flask_httpauth import HTTPBasicAuth, HTTPTokenAuth, MultiAuth, \
+    HTTPDigestAuth
+from werkzeug.http import parse_dict_header
 
 
 class HTTPAuthTestCase(unittest.TestCase):
@@ -11,7 +15,11 @@ class HTTPAuthTestCase(unittest.TestCase):
 
         basic_auth = HTTPBasicAuth()
         token_auth = HTTPTokenAuth('MyToken')
+        custom_token_auth = HTTPTokenAuth('MyToken', header='X-Api-Token')
+        digest_auth = HTTPDigestAuth(realm='My Realm')
         multi_auth = MultiAuth(basic_auth, token_auth)
+        token_digest_auth = MultiAuth(basic_auth, token_auth,
+                                      custom_token_auth, digest_auth)
 
         @basic_auth.verify_password
         def verify_password(username, password):
@@ -24,18 +32,26 @@ class HTTPAuthTestCase(unittest.TestCase):
                 return ['foo', 'bar']
 
         @token_auth.verify_token
+        @custom_token_auth.verify_token
         def verify_token(token):
             return token == 'this-is-the-token!'
 
         @token_auth.get_user_roles
+        @custom_token_auth.get_user_roles
         def get_token_role(auth):
             if auth['token'] == 'this-is-the-token!':
                 return 'foo'
             return
 
         @token_auth.error_handler
+        @custom_token_auth.error_handler
         def error_handler():
             return 'error', 401, {'WWW-Authenticate': 'MyToken realm="Foo"'}
+
+        @digest_auth.get_password
+        def get_password(username):
+            if username == 'john':
+                return 'hello'
 
         @app.route('/')
         def index():
@@ -50,6 +66,11 @@ class HTTPAuthTestCase(unittest.TestCase):
         @multi_auth.login_required(role='foo')
         def auth_role_route():
             return 'role access granted'
+
+        @app.route('/protected-with-digest')
+        @token_digest_auth.login_required
+        def auth_digest_route():
+            return 'access granted:' + str(multi_auth.current_user())
 
         self.app = app
         self.client = app.test_client()
@@ -98,6 +119,87 @@ class HTTPAuthTestCase(unittest.TestCase):
         self.assertTrue('WWW-Authenticate' in response.headers)
         self.assertEqual(response.headers['WWW-Authenticate'],
                          'Basic realm="Authentication Required"')
+
+    def test_multi_auth_prompt_digest(self):
+        response = self.client.get('/protected-with-digest')
+        self.assertEqual(response.status_code, 401)
+        self.assertTrue('WWW-Authenticate' in response.headers)
+        self.assertTrue(re.match(r'^Digest realm="My Realm",'
+                                 r'nonce="[0-9a-f]+",opaque="[0-9a-f]+"$',
+                                 response.headers['WWW-Authenticate']))
+
+    def test_multi_auth_login_valid_token_of_custom_header(self):
+        response = self.client.get(
+            '/protected-with-digest', headers={
+                'X-Api-Token': 'this-is-the-token!'})
+        self.assertEqual(response.data.decode('utf-8'), 'access granted:None')
+
+    def test_multi_auth_login_invalid_token_of_custom_header(self):
+        response = self.client.get(
+            '/protected-with-digest', headers={
+                'X-Api-Token': 'this-is-not-the-token!'})
+        self.assertEqual(response.status_code, 401)
+        self.assertTrue('WWW-Authenticate' in response.headers)
+        self.assertEqual(response.headers['WWW-Authenticate'],
+                         'MyToken realm="Foo"')
+
+    def test_multi_auth_login_valid_digest(self):
+        response = self.client.get('/protected-with-digest')
+        self.assertEqual(response.status_code, 401)
+        header = response.headers.get('WWW-Authenticate')
+        auth_type, auth_info = header.split(None, 1)
+        d = parse_dict_header(auth_info)
+
+        a1 = b'john:' + d['realm'].encode('utf-8') + b':hello'
+        ha1 = hashlib.md5(a1).hexdigest()
+        a2 = b'GET:/protected-with-digest'
+        ha2 = hashlib.md5(a2).hexdigest()
+        a3 = b''.join([ha1.encode('utf-8'), b':',
+                       d['nonce'].encode('utf-8'),
+                       b':', ha2.encode('utf-8')])
+        auth_response = hashlib.md5(a3).hexdigest()
+
+        response = self.client.get(
+            '/protected-with-digest', headers={
+                'Authorization': 'Digest username="john",realm="{0}",'
+                                 'nonce="{1}",uri="/protected-with-digest",'
+                                 'response="{2}",'
+                                 'opaque="{3}"'.format(d['realm'],
+                                                       d['nonce'],
+                                                       auth_response,
+                                                       d['opaque'])})
+        self.assertEqual(response.data, b'access granted:john')
+
+    def test_multi_auth_login_invalid_digest(self):
+        response = self.client.get('/protected-with-digest')
+        self.assertEqual(response.status_code, 401)
+        header = response.headers.get('WWW-Authenticate')
+        auth_type, auth_info = header.split(None, 1)
+        d = parse_dict_header(auth_info)
+
+        a1 = b'john:' + d['realm'].encode('utf-8') + b':bye'
+        ha1 = hashlib.md5(a1).hexdigest()
+        a2 = b'GET:/protected-with-digest'
+        ha2 = hashlib.md5(a2).hexdigest()
+        a3 = b''.join([ha1.encode('utf-8'), b':',
+                       d['nonce'].encode('utf-8'),
+                       b':', ha2.encode('utf-8')])
+        auth_response = hashlib.md5(a3).hexdigest()
+
+        response = self.client.get(
+            '/protected-with-digest', headers={
+                'Authorization': 'Digest username="john",realm="{0}",'
+                                 'nonce="{1}",uri="/protected-with-digest",'
+                                 'response="{2}",'
+                                 'opaque="{3}"'.format(d['realm'],
+                                                       d['nonce'],
+                                                       auth_response,
+                                                       d['opaque'])})
+        self.assertEqual(response.status_code, 401)
+        self.assertTrue('WWW-Authenticate' in response.headers)
+        self.assertTrue(re.match(r'^Digest realm="My Realm",'
+                                 r'nonce="[0-9a-f]+",opaque="[0-9a-f]+"$',
+                                 response.headers['WWW-Authenticate']))
 
     def test_multi_malformed_header(self):
         response = self.client.get(


### PR DESCRIPTION
+ If token auth is not `main_auth` with customized header, then `selected_auth` will always be `main_auth`
+ If digest auth is not `main_auth`, it return `main_auth` too, because there may no `Authorization` header in the first request of digest auth