### PR TITLE
Basic auth doesn't support : in username fix

### DIFF
--- a/src/flask_httpauth.py
+++ b/src/flask_httpauth.py
@@ -217,7 +217,7 @@ class HTTPBasicAuth(HTTPAuth):
         value = request.headers[header].encode('utf-8')
         try:
             scheme, credentials = value.split(b' ', 1)
-            username, password = b64decode(credentials).split(b':', 1)
+            username, password = b64decode(credentials).rsplit(b':', 1)
         except (ValueError, TypeError):
             return None
         try:


### PR DESCRIPTION
When using mac address as a username, the result is:
<mac address> 10:10:5e:00:23:cf
<result> 10
I researched for a while and it seems the rest of the mac address was moved to the password segment since the split by ':'. If we do split by last, the ':' character can be in the username.