### PR TITLE
Fix for Flask 2.3.0

### DIFF
--- a/src/flask_httpauth.py
+++ b/src/flask_httpauth.py
@@ -83,14 +83,24 @@ class HTTPAuth(object):
                 try:
                     auth_type, token = request.headers['Authorization'].split(
                         None, 1)
-                    auth = Authorization(auth_type, token=token)
+                    try:
+                        auth = Authorization(auth_type, token=token)
+                    except TypeError:
+                        # backwards compatibility for older Werkzeug
+                        auth = Authorization(auth_type)
+                        auth.token = token
                 except (ValueError, KeyError):
                     # The Authorization header is either empty or has no token
                     pass
         elif self.header in request.headers:
             # using a custom header, so the entire value of the header is
             # assumed to be a token
-            auth = Authorization(self.scheme, token=request.headers[self.header])
+            try:
+                auth = Authorization(self.scheme, token=request.headers[self.header])
+            except TypeError:
+                # backwards compatibility for older Werkzeug
+                auth = Authorization(self.scheme)
+                auth.token = request.headers[self.header]
 
         # if the auth type does not match, we act as if there is no auth
         # this is better than failing directly, as it allows the callback

--- a/src/flask_httpauth.py
+++ b/src/flask_httpauth.py
@@ -83,15 +83,14 @@ class HTTPAuth(object):
                 try:
                     auth_type, token = request.headers['Authorization'].split(
                         None, 1)
-                    auth = Authorization(auth_type, {'token': token})
+                    auth = Authorization(auth_type, token=token)
                 except (ValueError, KeyError):
                     # The Authorization header is either empty or has no token
                     pass
         elif self.header in request.headers:
             # using a custom header, so the entire value of the header is
             # assumed to be a token
-            auth = Authorization(self.scheme,
-                                 {'token': request.headers[self.header]})
+            auth = Authorization(self.scheme, token=request.headers[self.header])
 
         # if the auth type does not match, we act as if there is no auth
         # this is better than failing directly, as it allows the callback
@@ -392,7 +391,7 @@ class HTTPTokenAuth(HTTPAuth):
 
     def authenticate(self, auth, stored_password):
         if auth:
-            token = auth['token']
+            token = auth.token
         else:
             token = ""
         if self.verify_token_callback:

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -30,7 +30,7 @@ class HTTPAuthTestCase(unittest.TestCase):
 
         @token_auth.get_user_roles
         def get_token_role(auth):
-            if auth['token'] == 'this-is-the-token!':
+            if auth.token == 'this-is-the-token!':
                 return 'foo'
             return
 
@@ -44,7 +44,7 @@ class HTTPAuthTestCase(unittest.TestCase):
 
         @custom_token_auth.get_user_roles
         def get_custom_token_role(auth):
-            if auth['token'] == 'this-is-the-custom-token!':
+            if auth.token == 'this-is-the-custom-token!':
                 return 'foo'
             return
 

--- a/tests/test_multi_async.py
+++ b/tests/test_multi_async.py
@@ -33,7 +33,7 @@ class HTTPAuthTestCase(unittest.TestCase):
 
         @token_auth.get_user_roles
         async def get_token_role(auth):
-            if auth['token'] == 'this-is-the-token!':
+            if auth.token == 'this-is-the-token!':
                 return 'foo'
             return
 
@@ -47,7 +47,7 @@ class HTTPAuthTestCase(unittest.TestCase):
 
         @custom_token_auth.get_user_roles
         async def get_custom_token_role(auth):
-            if auth['token'] == 'this-is-the-custom-token!':
+            if auth.token == 'this-is-the-custom-token!':
                 return 'foo'
             return
 


### PR DESCRIPTION
Recently, Flask and Werkzeug updated to version 2.3.0 which broke the token authentication in Flask-HTTPAuth. After my careful look in the library and long search for the cause, I have discovered by due to the latest changes in Werkzeug's Authorization class, there are some problems with tokens.

What I am looking into is:
> Both classes have type, parameters, and token attributes. The token attribute supports auth schemes that use a single opaque token rather than key=value parameters, such as Bearer.

> Neither class is a dict anymore, although they still implement getting, setting, and deleting auth[key] and auth.key syntax, as well as auth.get(key) and key in auth.

I have successfully found the solution to this problem by changing how the token is preserved in the Authorization class.

Formerly it was:
```py
auth = Authorization(auth_type, {'token': token})
```

After my consideration, I have come to the conclusion that changing it to the form below will fix the problem:
```py
auth = Authorization(auth_type, token=token)
```

What I also changed was the method of retrieving the token from:
```py
token = auth['token']
```
to:
```py
token = auth.token
```

In addition to my understanding, it's also the preferred way of setting, keeping and retrieving the token as of now.

I have also updated all applicable tests (didn't find anything to change in examples or docs) so they use that method.

I made every effort I could to not introduce any breaking change in a code, although I would recommend checking it once again to make sure everything is as it should be.

Before committing I ran the tests with the latest versions of every package needed:
| Test | Passed |
|------|--------|
|test_basic_custom_realm|OK|
|test_basic_get_password|OK|
|test_basic_hashed_password|OK|
|test_basic_verify_password_async|OK|
|test_basic_verify_password|OK|
|test_digest_custom_realm|OK|
|test_digest_get_password|OK|
|test_digest_ha1_password|OK|
|test_digest_no_qop|OK|
|test_error_responses|OK|
|test_multi_async|OK (Modified)|
|test_multi|OK (Modified)|
|test_roles_async|OK|
|test_roles|OK|
|test_token_async|OK|
|test_token|OK|