### PR TITLE
Fix to Clear TCP Buffer on Unauthorized Large File Uploads in Swagger-UI (#138)

### DIFF
--- a/src/flask_httpauth.py
+++ b/src/flask_httpauth.py
@@ -164,6 +164,9 @@ class HTTPAuth(object):
                     elif not self.authorize(role, user, auth):
                         status = 403
                     if not optional and status:
+                        # Clear TCP receive buffer of any pending data, fixes failed to fetch on large data uploads
+                        while request.stream.read(64 * 1024):
+                            pass
                         try:
                             return self.auth_error_callback(status)
                         except TypeError:


### PR DESCRIPTION
This PR addresses and improves the security issue originally raised in [#138](https://github.com/miguelgrinberg/Flask-HTTPAuth/issues/138), where unauthorized large file uploads caused the backend to process the request, leading to potential DoS attacks. At the time, the request data was being read despite authentication failure, filling the disk or memory with large temporary files. We removed any data processing back then on unauthorized requests.

Upon further investigation and many years, we now have a deeper understanding of the previous behavior and why it was once there. The primary reason for initially reading the request data was not to process or store the uploaded form data, but to avoid a "failed to fetch" error reported by Swagger-UI due to incomplete request processing. When form data is uploaded, the backend must **receive** the data entirely, even if the request is unauthorized, or else the client fails to receive the backend response properly (Failed to Fetch error).

### Proposed Fix:
Instead of parsing and processing the form data, the TCP receive buffer is cleared by reading the incoming stream in chunks of 64KB, **discarding** the data. This approach solves the "failed to fetch" error while preventing unauthorized form uploads from being processed unnecessarily.

### References:
- Original issue: [#138](https://github.com/miguelgrinberg/Flask-HTTPAuth/issues/138)
