### PR TITLE
fix the type of scheme

### DIFF
--- a/src/flask_httpauth.py
+++ b/src/flask_httpauth.py
@@ -224,10 +224,12 @@ class HTTPBasicAuth(HTTPAuth):
         except (ValueError, TypeError):
             return None
         try:
+            scheme = scheme.decode('utf-8')
             username = encoded_username.decode('utf-8')
             password = encoded_password.decode('utf-8')
         except UnicodeDecodeError:
             # try to decode again with latin-1, which should always work
+            scheme = scheme.decode('latin1')
             username = encoded_username.decode('latin1')
             password = encoded_password.decode('latin1')
 


### PR DESCRIPTION
The Authorization class of Werkzeug expects an auth_type of type str.

Refer: [werkzeug/datastructures/auth.py#L45](https://github.com/pallets/werkzeug/blob/7868bef5d978093a8baa0784464ebe5d775ae92a/src/werkzeug/datastructures/auth.py#L45)