### PR TITLE
Restore warning about Digest server-side session requirement

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -72,6 +72,50 @@ The following example uses HTTP Digest authentication::
     if __name__ == '__main__':
         app.run()
 
+Security Concerns with Digest Authentication
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The digest authentication algorithm requires a *challenge* to be sent to the
+client for use in encrypting the password for transmission. This challenge
+needs to be used again when the password is decoded at the server, so the
+challenge information needs to be stored so that it can be recalled later.
+
+By default, Flask-HTTPAuth stores the challenge data in the Flask session. To
+make the authentication flow secure when using session storage, it is required
+that server-side sessions are used instead of the default Flask cookie based
+sessions, as this ensures that the challenge data is not at risk of being
+captured as it moves in a cookie between server and client. The Flask-Session
+and Flask-KVSession extensions are both very good options to implement
+server-side sessions.
+
+As an alternative to using server-side sessions, an application can implement
+its own generation and storage of challenge data. To do this, there are four
+callback functions that the application needs to implement::
+
+    @auth.generate_nonce
+    def generate_nonce():
+        """Return the nonce value to use for this client."""
+        pass
+
+    @auth.generate_opaque
+    def generate_opaque():
+        """Return the opaque value to use for this client."""
+        pass
+
+    @auth.verify_nonce
+    def verify_nonce(nonce):
+        """Verify that the nonce value sent by the client is correct."""
+        pass
+
+    @auth.verify_opaque
+    def verify_opaque(opaque):
+        """Verify that the opaque value sent by the client is correct."""
+        pass
+
+For information of what the ``nonce`` and ``opaque`` values are and how they
+are used in digest authentication, consult
+`RFC 2617 <http://tools.ietf.org/html/rfc2617#section-3.2.1>`_.
+
 Token Authentication Example
 ----------------------------
 

--- a/src/flask_httpauth.py
+++ b/src/flask_httpauth.py
@@ -419,6 +419,12 @@ class HTTPDigestAuth(HTTPAuth):
     The ``algorithm`` option configures the hash generation algorithm to use.
     The default is ``MD5``. The two algorithms that are implemented are ``MD5``
     and ``MD5-Sess``.
+
+    Note: By default, the ``nonce`` and ``opaque`` values that are assigned to
+    each client are stored in the Flask session. To keep these values secured,
+    server-side sessions such as those provided by the Flask-Session and
+    Flask-KVSession extensions should be used. With the default cookie-based
+    sessions provided by Flask, there is risk that these values can be leaked.
     """
     def __init__(self, scheme=None, realm=None, use_ha1_pw=False, qop='auth',
                  algorithm='MD5'):


### PR DESCRIPTION
A warning about the requirement to use server-side sessions when using Digest authentication was inadvertently deleted in [#b42168](https://github.com/miguelgrinberg/Flask-HTTPAuth/commit/b42168ed174cde0a9404dbf0b05b5b5c5d6eb46d). The warning is restored in this change. The releases that had this warning omitted are 4.7.0, 4.8.0 and 4.8.1.
